### PR TITLE
Support Java 21 builds

### DIFF
--- a/.github/workflows/main_push_and_pull_request_workflow.yml
+++ b/.github/workflows/main_push_and_pull_request_workflow.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [ 11, 17 ]
+        java-version: [ 11, 17, 21 ]
     name: Build on ${{ matrix.runs-on }} with jdk ${{ matrix.java-version }}
     runs-on: ubuntu-latest
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ subprojects {
     pitest {
         //adds dependency to org.pitest:pitest-junit5-plugin and sets "testPlugin" to "junit5"
         junit5PluginVersion = '1.2.0'
-        pitestVersion = '1.14.2'
+        pitestVersion = '1.16.3'
         targetClasses.add("io.aiven.kafka.tieredstorage.*")  //by default "${project.group}.*"
         targetTests.add("io.aiven.kafka.tieredstorage.*")  //by default "${project.group}.*"
         threads = Runtime.getRuntime().availableProcessors()

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/transform/RateLimitedInputStream.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/transform/RateLimitedInputStream.java
@@ -32,7 +32,8 @@ import io.github.bucket4j.local.SynchronizationStrategy;
  */
 public class RateLimitedInputStream extends FilterInputStream {
     // default buffer size used by InputStream#DEFAULT_BUFFER_SIZE when transferring to output stream
-    static final int MIN_RATE = 8192;
+    // As of JDK 21, InputStream#DEFAULT_BUFFER_SIZE has been changed to 16384.
+    static final int MIN_RATE = Runtime.version().feature() >= 21 ? 16384 : 8192;
 
     final Bucket bucket;
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=5625a0ae20fe000d9225d000b36909c7a0e0e8dda61c19b12da769add847c975
+distributionSha256Sum=f8b4f4772d302c8ff580bc40d0f56e715de69b163546944f787c87abf209c961


### PR DESCRIPTION
This PR upgrades the Gradle and library versions and modifies the code to support building with Java 21.

- upgrade gradle: 8.1.1 → 8.8 (Java 21 needs gradle >= 8.5. see: https://docs.gradle.org/8.5/release-notes.html#java-21)
- upgrade pitest: 1.14.2 → 1.16.3 (Java 21 needs pitest >= 1.15.0 see: https://stackoverflow.com/a/77261168)
- change RateLimitedInputStream:: MIN_RATE: 8192 → 16384 (see: https://bugs.openjdk.org/browse/JDK-8299336)

